### PR TITLE
Add Japanese Nintendo DSi Sound launcharg

### DIFF
--- a/7zfile/DSiWare (JAP)/Nintendo DSi Sound (J).launcharg
+++ b/7zfile/DSiWare (JAP)/Nintendo DSi Sound (J).launcharg
@@ -1,0 +1,1 @@
+sd:/title/00030005/484e4b4a/content/00000002.app


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
Added launcharg file for Nintendo DSi Sound on Japanese consoles

#### Where have you tested it?

On my Japanese DSi with Unlaunch 1.3, Hiya 1.3.2, and TWiLight 6.4.1

*** 
#### Pull Request status
- [ ]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  
(I don't know how to build stuff ^, but it's just a launcharg file and it works)
_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.
